### PR TITLE
Update o365_rules.py

### DIFF
--- a/o365_rules.py
+++ b/o365_rules.py
@@ -140,7 +140,7 @@ for endpoint in o365_data:
                 print('DEBUG: endpoint:', str(endpoint))
 
     # App Rule
-    elif ('tcpPorts' in endpoint) and ((endpoint['tcpPorts'] == "80,443") or (endpoint['tcpPorts'] == "443") or (endpoint['tcpPorts'] == "80")):
+    elif ('tcpPorts' in endpoint) and ((endpoint['tcpPorts'] == "80,443") or (endpoint['tcpPorts'] == "443,80") or (endpoint['tcpPorts'] == "443") or (endpoint['tcpPorts'] == "80")):
         cnt_apprules += 1
         if 'urls' in endpoint:
             new_rule = {


### PR DESCRIPTION
Adding condition match for app rule creation with tcp ports 443,80  --- without this condition, the script is throwing errors with the newly added endpoints with these port orders. With this fix, the script is working flawlessly.

Previously the condition match was only 80,443 -- but there are a few new endpoints which have the reverse order and this port order should match otherwise this script is creating a network rule and network rule does not allow '*' in the fqdn. So for proper app rule creation, we need this condition. We have tested this and it is working.